### PR TITLE
Expand domains for cert on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This container provides a nginx with LetsEncypt enabled.  When tested with SSLLa
 ## How nginx is initially setup
 
 1. `EMAIL` environment variable specifies the email address that will recieve the notifications when there is a renewal needed
-2. `SERVERS` environment variable specifies a *comma* separated list of FQDNs for the certificate.  It is expected that the first one would be primary and will be put in the `/etc/letsencrypt/live` folder.  (Comma separated was choses to avoid the hassle of adding extra quotes)
+2. `DOMAINS` environment variable specifies a *comma* separated list of FQDNs for the certificate.  It is expected that the first one would be primary and will be put in the `/etc/letsencrypt/live` folder.  (Comma separated was choses to avoid the hassle of adding extra quotes)
 3. When the `/etc/letsencrypt/live folder` is missing the `init` script will start up `certbot` in standalone mode.  This will create the necessary files to enable SSL.  Otherwise we would require two configuration files for nginx (one with and one without SSL).
 
 # Customization points

--- a/init.sh
+++ b/init.sh
@@ -19,7 +19,10 @@ if [ -e /etc/letsencrypt/live ]
 then
   certbot -n -q certonly --expand --standalone --email ${EMAIL} --agree-tos --rsa-key-size 4096 --domains ${DOMAINS}
 else
-  openssl dhparam -out /etc/letsencrypt/dhparam.pem 4096 > /dev/null 2>&1 &
+  echo "Generating ssl dhparam for nginx ..."
+  # see https://security.stackexchange.com/a/95184/26281
+  openssl dhparam -dsaparam -out /etc/letsencrypt/dhparam.pem 4096 > /dev/null 2>&1 &
+  echo "Done generating ssl dhparam"
   certbot -n -q certonly --standalone --email ${EMAIL} --agree-tos --rsa-key-size 4096 --domains ${DOMAINS}
   wait
 fi

--- a/init.sh
+++ b/init.sh
@@ -19,10 +19,8 @@ if [ -e /etc/letsencrypt/live ]
 then
   certbot -n -q certonly --expand --standalone --email ${EMAIL} --agree-tos --rsa-key-size 4096 --domains ${DOMAINS}
 else
-  echo "Generating ssl dhparam for nginx ..."
   # see https://security.stackexchange.com/a/95184/26281
   openssl dhparam -dsaparam -out /etc/letsencrypt/dhparam.pem 4096 > /dev/null 2>&1 &
-  echo "Done generating ssl dhparam"
   certbot -n -q certonly --standalone --email ${EMAIL} --agree-tos --rsa-key-size 4096 --domains ${DOMAINS}
   wait
 fi

--- a/init.sh
+++ b/init.sh
@@ -17,7 +17,7 @@ flock -s 200
 
 if [ -e /etc/letsencrypt/live ]
 then
-  certbot renew -a webroot -w /tmp
+  certbot -n -q certonly --expand --standalone --email ${EMAIL} --agree-tos --rsa-key-size 4096 --domains ${DOMAINS}
 else
   openssl dhparam -out /etc/letsencrypt/dhparam.pem 4096 > /dev/null 2>&1 &
   certbot -n -q certonly --standalone --email ${EMAIL} --agree-tos --rsa-key-size 4096 --domains ${DOMAINS}


### PR DESCRIPTION
* Expand domains for CERT on start in case a new domain is added.
* Generate DSA-like dhparam instead of default, which might take hours on low-end cpu, see https://security.stackexchange.com/a/95184/26281