### PR TITLE
(new) upgrade certbot from 0.25 to 1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM nginx:1.15.5-alpine
+FROM nginx:1.18.0-alpine
 LABEL maintainer="archie@trajano.net"
+ENV NGINX_VERSION=1.18.0 \
+    CERTBOT_VERSION=1.0.0
 EXPOSE 443
 VOLUME /etc/letsencrypt
-RUN apk add py-urllib3 openssl certbot curl bash --no-cache --repository http://dl-3.alpinelinux.org/alpine/v3.7/community/ --repository http://dl-3.alpinelinux.org/alpine/v3.7/main/ \
+RUN apk add py-urllib3 openssl certbot curl bash \
   && rm -rf /var/cache/apk/*
 COPY certbot-renew.sh /
 COPY nginx-files/* /etc/nginx/


### PR DESCRIPTION
According to LetsEncrypt:

> Beginning June 1, 2020, we will stop allowing new domains to validate using
the ACMEv1 protocol. You should upgrade to an ACMEv2 compatible client before
then, or certificate issuance will fail.  

This upgrades alpine to 3.11, which bundles certbot 1.0.0 with ACMEv2 support.

#### Upgrade notice

After applying this image, verify in the container that certbot works with ACMEv2:

```
certbot renew -a webroot -w /tmp  --deploy-hook "nginx -s reload" --server https://acme-v02.api.letsencrypt.org/directory
```

Then update the version in the renewal config:

```
sed -i "s/version = 0.25.1/version = 1.0.0/g" /etc/letsencrypt/renewal/*.conf
```

If there is `server =` config, remove it, or set it as above command.

See
* https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1
* https://community.letsencrypt.org/t/some-certificates-use-acme-v02-olds-use-acme-v01/117818
